### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,42 +1,53 @@
-# Visit https://github.com/lowlighter/metrics#-documentation for full reference
+# GitHub Metrics Workflow
+# For full reference, visit: https://github.com/lowlighter/metrics#-documentation
 name: Metrics
+
 on:
-  # Schedule updates (each hour)
-  schedule: [{cron: "0 * * * *"}]
-  # Lines below let you run workflow manually and on each commit
-  workflow_dispatch:
-  push: {branches: ["master", "main"]}
+  # Schedule updates every hour.
+  schedule:
+    - cron: "0 * * * *"
+  # Allow manual runs and runs on push to master/main.
+  workflow_dispatch: {}
+  push:
+    branches: ["master", "main"]
+
 jobs:
   github-metrics:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
-      - uses: lowlighter/metrics@latest
-        with:
-          # Your GitHub token
-          # The following scopes are required:
-          #  - public_access (default scope)
-          # The following additional scopes may be required:
-          #  - read:org      (for organization related metrics)
-          #  - read:user     (for user related data)
-          #  - read:packages (for some packages related data)
-          #  - repo          (optional, if you want to include private repositories)
-          token: ${{ secrets.METRICS_TOKEN }}
+      # Check out the repository in case the action needs to update files.
+      - name: Checkout Repository
+        uses: actions/checkout@v3
 
+      # Run the Metrics action.
+      - name: Run GitHub Metrics
+        uses: lowlighter/metrics@latest
+        with:
+          # GitHub token with appropriate scopes.
+          token: ${{ secrets.METRICS_TOKEN }}
+          
           # Options
           user: CompuGenius-Programs
           template: classic
           base: header, activity, community, repositories, metadata
           base_hireable: yes
           config_timezone: America/New_York
+          
+          # Plugin settings for code analysis.
           plugin_code: yes
           plugin_code_days: 365
           plugin_code_lines: 12
           plugin_code_load: 400
           plugin_code_visibility: public
+          
+          # Plugin settings for introduction section.
           plugin_introduction: yes
           plugin_introduction_title: yes
+          
+          # Plugin settings for language analysis.
           plugin_languages: yes
           plugin_languages_analysis_timeout: 15
           plugin_languages_analysis_timeout_repositories: 7.5
@@ -48,10 +59,16 @@ jobs:
           plugin_languages_recent_days: 14
           plugin_languages_recent_load: 300
           plugin_languages_sections: most-used
-          plugin_languages_threshold: 0%
+          plugin_languages_threshold: "0%"
+          
+          # Plugin settings for notable contributions.
           plugin_notable: yes
           plugin_notable_from: all
           plugin_notable_types: commit
+          
+          # Plugin settings for star metrics.
           plugin_stars: yes
           plugin_stars_limit: 4
+          
+          # Batch size for repository queries.
           repositories_batch: 100


### PR DESCRIPTION
Checkout Step: Added a step using actions/checkout@v3 to ensure that the repository is available if Metrics needs to update files (for example, updating a README with generated metrics). Job Timeout: Added a timeout-minutes: 10 option to ensure that the job won’t run indefinitely. Clarifying Comments: Comments have been updated and expanded to explain each section and setting. Parameter Adjustments: The value for plugin_languages_threshold is quoted ("0%") to avoid YAML parsing issues. This revised workflow should provide you with a more robust and maintainable setup for running GitHub Metrics on your repository.